### PR TITLE
fix: Inserts the execution of the update script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
 
 script:
   - docker-compose up -d && docker-compose exec magento install_pagarme && docker-compose exec magento update && docker-compose exec magento install-sampledata
-  - behat --config ${PATH_MODULE}/behat.yml
+  - docker-compose exec magento behat --config ${PATH_MODULE}/behat.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 script:
-  - docker-compose up -d && docker-compose exec magento install_pagarme && docker-compose exec magento install-sampledata
+  - docker-compose up -d && docker-compose exec magento install_pagarme && docker-compose exec magento update && docker-compose exec magento install-sampledata
   - behat --config ${PATH_MODULE}/behat.yml


### PR DESCRIPTION
When Travis try to install the sampledata, it breaks because don't have
permission to /generated. To solve this problem I insert the execution
of the update script, tha gives permission to the folder.