### PR TITLE
Set archive configurations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,13 @@
     },
     "config":{
         "secure-http":false
+    },
+    "archive":{
+        "exclude":[
+            "/docker",
+            "docker-compose.yml",
+            ".travis.yml",
+            ".env"
+        ]
     }
 }


### PR DESCRIPTION
Composer allow us to create zip/tar files for a given package. This set
of configurations will exclude files/directories that doesn't matter to
the module